### PR TITLE
feat: add notifications facade, logging proxy and output bridge

### DIFF
--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -70,21 +70,21 @@ Requirements for issues #4-#8. Each maps to one roadmap phase.
 
 ### Notifications & Logging (#8)
 
-- [ ] **NOTF-01**: Facade provides NotifyUser and NotifyOrderStatusChanged methods
-- [ ] **NOTF-02**: Facade internally uses ConsoleNotifier and FileNotifier subsystems
-- [ ] **NOTF-03**: POST /api/notifications/send sends notification via facade
-- [ ] **NOTF-04**: Proxy wraps Logger interface with lazy initialization
-- [ ] **NOTF-05**: LoggerProxy counts log entries (GetLogCount)
-- [ ] **NOTF-06**: LoggerProxy filters by log level (info, warn, error)
-- [ ] **NOTF-07**: GET /api/logs?level= returns filtered log entries
-- [ ] **NOTF-08**: GET /api/logs/stats returns log counts by level
-- [ ] **NOTF-09**: Bridge separates Formatter abstraction from OutputWriter implementation
-- [ ] **NOTF-10**: TextFormatter and JSONFormatter as abstraction variants
-- [ ] **NOTF-11**: ConsoleWriter and FileWriter as implementor variants
-- [ ] **NOTF-12**: Unit tests for Facade (multi-channel notification)
-- [ ] **NOTF-13**: Unit tests for Proxy (lazy init, counter, level filtering)
-- [ ] **NOTF-14**: Unit tests for Bridge (all formatter+writer combinations)
-- [ ] **NOTF-15**: HTTP handler tests for notification and logging endpoints
+- [x] **NOTF-01**: Facade provides NotifyUser and NotifyOrderStatusChanged methods
+- [x] **NOTF-02**: Facade internally uses ConsoleNotifier and FileNotifier subsystems
+- [x] **NOTF-03**: POST /api/notifications/send sends notification via facade
+- [x] **NOTF-04**: Proxy wraps Logger interface with lazy initialization
+- [x] **NOTF-05**: LoggerProxy counts log entries (GetLogCount)
+- [x] **NOTF-06**: LoggerProxy filters by log level (info, warn, error)
+- [x] **NOTF-07**: GET /api/logs?level= returns filtered log entries
+- [x] **NOTF-08**: GET /api/logs/stats returns log counts by level
+- [x] **NOTF-09**: Bridge separates Formatter abstraction from OutputWriter implementation
+- [x] **NOTF-10**: TextFormatter and JSONFormatter as abstraction variants
+- [x] **NOTF-11**: ConsoleWriter and FileWriter as implementor variants
+- [x] **NOTF-12**: Unit tests for Facade (multi-channel notification)
+- [x] **NOTF-13**: Unit tests for Proxy (lazy init, counter, level filtering)
+- [x] **NOTF-14**: Unit tests for Bridge (all formatter+writer combinations)
+- [x] **NOTF-15**: HTTP handler tests for notification and logging endpoints
 
 ## v2 Requirements
 
@@ -162,21 +162,21 @@ Which phases cover which requirements. Updated during roadmap creation.
 | CART-11 | Phase 4 | Complete |
 | CART-12 | Phase 4 | Complete |
 | CART-13 | Phase 4 | Complete |
-| NOTF-01 | Phase 5 | Pending |
-| NOTF-02 | Phase 5 | Pending |
-| NOTF-03 | Phase 5 | Pending |
-| NOTF-04 | Phase 5 | Pending |
-| NOTF-05 | Phase 5 | Pending |
-| NOTF-06 | Phase 5 | Pending |
-| NOTF-07 | Phase 5 | Pending |
-| NOTF-08 | Phase 5 | Pending |
-| NOTF-09 | Phase 5 | Pending |
-| NOTF-10 | Phase 5 | Pending |
-| NOTF-11 | Phase 5 | Pending |
-| NOTF-12 | Phase 5 | Pending |
-| NOTF-13 | Phase 5 | Pending |
-| NOTF-14 | Phase 5 | Pending |
-| NOTF-15 | Phase 5 | Pending |
+| NOTF-01 | Phase 5 | Complete |
+| NOTF-02 | Phase 5 | Complete |
+| NOTF-03 | Phase 5 | Complete |
+| NOTF-04 | Phase 5 | Complete |
+| NOTF-05 | Phase 5 | Complete |
+| NOTF-06 | Phase 5 | Complete |
+| NOTF-07 | Phase 5 | Complete |
+| NOTF-08 | Phase 5 | Complete |
+| NOTF-09 | Phase 5 | Complete |
+| NOTF-10 | Phase 5 | Complete |
+| NOTF-11 | Phase 5 | Complete |
+| NOTF-12 | Phase 5 | Complete |
+| NOTF-13 | Phase 5 | Complete |
+| NOTF-14 | Phase 5 | Complete |
+| NOTF-15 | Phase 5 | Complete |
 
 **Coverage:**
 - v1 requirements: 64 total

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -89,7 +89,11 @@ Plans:
   2. GET /api/logs?level=X returns log entries filtered by level via LoggerProxy; GET /api/logs/stats returns counts by level
   3. All formatter+writer Bridge combinations (Text/JSON x Console/File) produce correct output
   4. Facade, Proxy, and Bridge unit and handler tests all pass
-**Plans**: TBD
+**Plans:** 1/3 plans executed
+Plans:
+- [x] 05-01-PLAN.md — Facade pattern: NotificationFacade with ConsoleNotifier + FileNotifier + unit tests
+- [x] 05-02-PLAN.md — Proxy + Bridge patterns: LoggerProxy + OutputWriter/Formatter + unit tests
+- [x] 05-03-PLAN.md — HTTP handlers for notification/logging endpoints + handler tests + route registration
 
 ## Progress
 
@@ -102,4 +106,4 @@ Phases execute in order: 1 -> 2 -> 3/4/5 (3, 4, 5 independent after Phase 2)
 | 2. Order Lifecycle | 3/3 | Complete    | 2026-04-07 |
 | 3. Search & Chat | 0/3 | Planning complete | - |
 | 4. Cart & Export | 3/3 | Complete   | 2026-04-07 |
-| 5. Notifications & Logging | 0/TBD | Not started | - |
+| 5. Notifications & Logging | 1/3 | In Progress|  |

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -3,14 +3,14 @@ gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
 status: verifying
-stopped_at: Completed 04-cart-export/04-03-PLAN.md
-last_updated: "2026-04-07T22:23:02.343Z"
+stopped_at: Completed 05-notifications-logging plan 03
+last_updated: "2026-04-07T22:36:42.340Z"
 last_activity: 2026-04-07
 progress:
   total_phases: 5
-  completed_phases: 4
-  total_plans: 11
-  completed_plans: 11
+  completed_phases: 5
+  total_plans: 14
+  completed_plans: 14
   percent: 100
 ---
 
@@ -56,6 +56,9 @@ Progress: [░░░░░░░░░░] 0%
 | Phase 04-cart-export P01 | 15 | 2 tasks | 2 files |
 | Phase 04-cart-export P02 | 10 | 2 tasks | 2 files |
 | Phase 04-cart-export P03 | 15 | 2 tasks | 3 files |
+| Phase 05-notifications-logging P01 | 15 | 2 tasks | 2 files |
+| Phase 05-notifications-logging P02 | 525604 | 3 tasks | 4 files |
+| Phase 05-notifications-logging P03 | 10 | 2 tasks | 3 files |
 
 ## Accumulated Context
 
@@ -71,6 +74,12 @@ Recent decisions affecting current work:
 - [Phase 04-cart-export]: OrderVisitor uses distinct VisitItem/VisitCart method names — Go has no method overloading
 - [Phase 04-cart-export]: Rollback Memento snapshot on failed remove to keep CartHistory consistent
 - [Phase 04-cart-export]: Single HandleCart multiplexer matches existing OrderHandler pattern
+- [Phase 05-notifications-logging]: Facade uses io.Writer injection for ConsoleNotifier and FileNotifier to enable test isolation without real I/O
+- [Phase 05-notifications-logging]: errors.Join aggregates multi-channel notification errors so partial failures are not swallowed
+- [Phase 05-02]: Use fmt.Sprintf with %q verb for JSON formatting to avoid encoding/json dependency
+- [Phase 05-02]: levelValue helper maps info=0/warn=1/error=2 for simple level comparison
+- [Phase 05-03]: Both console and file writers point to os.Stdout in educational demo
+- [Phase 05-03]: Log stats counts computed per-level by iterating GetEntries result
 
 ### Pending Todos
 
@@ -82,6 +91,6 @@ None yet.
 
 ## Session Continuity
 
-Last session: 2026-04-07T22:23:02.341Z
-Stopped at: Completed 04-cart-export/04-03-PLAN.md
+Last session: 2026-04-07T22:36:42.337Z
+Stopped at: Completed 05-notifications-logging plan 03
 Resume file: None

--- a/.planning/phases/05-notifications-logging/05-01-PLAN.md
+++ b/.planning/phases/05-notifications-logging/05-01-PLAN.md
@@ -1,0 +1,171 @@
+---
+phase: 05-notifications-logging
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/notify/facade.go
+  - internal/notify/facade_test.go
+autonomous: true
+requirements:
+  - NOTF-01
+  - NOTF-02
+  - NOTF-12
+
+must_haves:
+  truths:
+    - "NotifyUser sends message through both ConsoleNotifier and FileNotifier"
+    - "NotifyOrderStatusChanged formats and sends through both channels"
+    - "Facade returns aggregated errors from subsystems"
+  artifacts:
+    - path: "internal/notify/facade.go"
+      provides: "NotificationFacade with ConsoleNotifier and FileNotifier subsystems"
+      exports: ["Notifier", "ConsoleNotifier", "FileNotifier", "NotificationFacade", "NewNotificationFacade", "NotifyUser", "NotifyOrderStatusChanged"]
+    - path: "internal/notify/facade_test.go"
+      provides: "Unit tests for Facade pattern"
+  key_links:
+    - from: "NotificationFacade"
+      to: "ConsoleNotifier, FileNotifier"
+      via: "internal composition — facade holds both notifiers"
+      pattern: "ConsoleNotifier|FileNotifier"
+---
+
+<objective>
+Implement the Facade pattern for notifications: a NotificationFacade that hides the complexity of sending through multiple notification channels (ConsoleNotifier + FileNotifier) behind simple NotifyUser and NotifyOrderStatusChanged methods.
+
+Purpose: Demonstrate the Facade pattern — a unified simple interface over complex subsystems.
+Output: internal/notify/facade.go with Facade + subsystems, internal/notify/facade_test.go with unit tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@TASKS.md
+@cmd/server/main.go
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Implement Facade pattern — NotificationFacade with ConsoleNotifier and FileNotifier</name>
+  <files>internal/notify/facade.go</files>
+  <read_first>
+    - internal/notification/observer.go (existing notification patterns for consistency)
+    - TASKS.md (Issue #8 Facade spec)
+  </read_first>
+  <behavior>
+    - NotifyUser("user1", "hello") calls both ConsoleNotifier and FileNotifier
+    - NotifyOrderStatusChanged("order1", "shipped") formats message and sends through both channels
+    - If one notifier fails, error is still returned (errors not swallowed per Pitfall 10)
+    - ConsoleNotifier writes to an io.Writer (configurable for testing, defaults to os.Stdout)
+    - FileNotifier writes to an io.Writer (configurable for testing, can be bytes.Buffer)
+  </behavior>
+  <action>
+Create `internal/notify/facade.go` with:
+
+1. `Notifier` interface with `Notify(userID, message string) error` method.
+
+2. `ConsoleNotifier` struct holding an `io.Writer` field (default os.Stdout). Method `Notify(userID, message string) error` writes formatted message like `[CONSOLE] User user1: hello\n` to the writer.
+
+3. `FileNotifier` struct holding an `io.Writer` field (for testability — in production this would be a file). Method `Notify(userID, message string) error` writes formatted message like `[FILE] User user1: hello\n` to the writer.
+
+4. `NotificationFacade` struct with fields:
+   - `notifiers []Notifier` (holds ConsoleNotifier and FileNotifier)
+
+5. `NewNotificationFacade(console io.Writer, file io.Writer) *NotificationFacade` constructor that creates both notifiers and stores them.
+
+6. `NotifyUser(userID, message string) error` — iterates all notifiers, calls Notify on each, aggregates errors with `errors.Join`.
+
+7. `NotifyOrderStatusChanged(orderID, status string) error` — formats message as `"Order orderID status changed to status"` then calls NotifyUser with userID="system".
+
+Follow existing conventions: PascalCase exports, Ukrainian comments for type docs, receiver single letter `f` for facade, `n` for notifier.
+  </action>
+  <acceptance_criteria>
+    - grep -q "type Notifier interface" internal/notify/facade.go
+    - grep -q "type ConsoleNotifier struct" internal/notify/facade.go
+    - grep -q "type FileNotifier struct" internal/notify/facade.go
+    - grep -q "type NotificationFacade struct" internal/notify/facade.go
+    - grep -q "func (f \*NotificationFacade) NotifyUser" internal/notify/facade.go
+    - grep -q "func (f \*NotificationFacade) NotifyOrderStatusChanged" internal/notify/facade.go
+    - grep -q "errors.Join" internal/notify/facade.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go build ./internal/notify/...</automated>
+  </verify>
+  <done>NotificationFacade struct exists with NotifyUser and NotifyOrderStatusChanged methods. ConsoleNotifier and FileNotifier both implement Notifier interface. Facade uses errors.Join to propagate subsystem errors.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Unit tests for Facade pattern</name>
+  <files>internal/notify/facade_test.go</files>
+  <read_first>
+    - internal/notify/facade.go (just created)
+    - internal/notification/observer_test.go (test style reference)
+  </read_first>
+  <behavior>
+    - TestNotifyUser_SendsToBothChannels: NotifyUser writes to both console and file writers
+    - TestNotifyOrderStatusChanged_FormatsMessage: includes orderID and status in output
+    - TestFacade_ErrorPropagation: if a notifier returns error, facade returns non-nil error
+  </behavior>
+  <action>
+Create `internal/notify/facade_test.go` with:
+
+1. `TestNotifyUser_SendsToBothChannels` — create facade with two `bytes.Buffer` writers, call `NotifyUser("user1", "test message")`, assert both buffers contain expected output (check strings.Contains for "[CONSOLE]" and "[FILE]").
+
+2. `TestNotifyOrderStatusChanged_FormatsMessage` — create facade with two `bytes.Buffer` writers, call `NotifyOrderStatusChanged("order-1", "shipped")`, assert output contains "order-1" and "shipped".
+
+3. `TestFacade_ErrorPropagation` — create a custom `errorNotifier` that implements Notifier and always returns an error. Verify that when facade includes this notifier, the returned error is non-nil. To test this, either add a method to add notifiers or create facade then append to its notifiers slice (if exported), or create an alternative constructor for testing. Simplest: make `Notifiers` field or provide `AddNotifier` method. OR: create a `failingWriter` that returns error on Write — the notifier will propagate it.
+
+Use `bytes.Buffer` for both console and file io.Writer params. Follow existing test conventions: table-driven where appropriate, `t.Run` for subtests.
+  </action>
+  <acceptance_criteria>
+    - grep -q "TestNotifyUser" internal/notify/facade_test.go
+    - grep -q "TestNotifyOrderStatusChanged" internal/notify/facade_test.go
+    - grep -q "TestFacade_ErrorPropagation\|TestNotify.*Error" internal/notify/facade_test.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go test ./internal/notify/ -v -count=1</automated>
+  </verify>
+  <done>All Facade unit tests pass. Tests verify multi-channel notification, message formatting, and error propagation.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| N/A | No external input in this plan — Facade is internal domain logic |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation |
+|-----------|----------|-----------|-------------|------------|
+| T-05-01 | D (Denial of Service) | FileNotifier writing to disk | accept | Educational project; no production file I/O concerns |
+| T-05-02 | I (Info Disclosure) | Console output of notifications | accept | Educational project; no sensitive data in notifications |
+</threat_model>
+
+<verification>
+- `go test ./internal/notify/ -v` passes all tests
+- `go vet ./internal/notify/` reports no issues
+- `go build ./internal/notify/` compiles cleanly
+</verification>
+
+<success_criteria>
+- NotificationFacade.NotifyUser sends through ConsoleNotifier and FileNotifier
+- NotificationFacade.NotifyOrderStatusChanged formats and delegates to NotifyUser
+- Facade propagates errors (not swallowed)
+- All unit tests pass
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-notifications-logging/05-01-SUMMARY.md`
+</output>

--- a/.planning/phases/05-notifications-logging/05-01-SUMMARY.md
+++ b/.planning/phases/05-notifications-logging/05-01-SUMMARY.md
@@ -1,0 +1,73 @@
+---
+phase: 05-notifications-logging
+plan: 01
+subsystem: notify
+tags: [facade, pattern, notifications, go]
+dependency_graph:
+  requires: []
+  provides: [internal/notify]
+  affects: []
+tech_stack:
+  added: []
+  patterns: [Facade]
+key_files:
+  created:
+    - internal/notify/facade.go
+    - internal/notify/facade_test.go
+  modified: []
+decisions:
+  - Used io.Writer for ConsoleNotifier and FileNotifier to allow testing without real I/O
+  - errors.Join aggregates partial failures so no channel error is silently dropped
+metrics:
+  duration_minutes: 15
+  completed: "2026-04-07T22:30:47Z"
+  tasks_completed: 2
+  files_changed: 2
+---
+
+# Phase 05 Plan 01: Facade Pattern — NotificationFacade Summary
+
+**One-liner:** NotificationFacade hiding ConsoleNotifier + FileNotifier complexity behind NotifyUser and NotifyOrderStatusChanged using stdlib errors.Join for error aggregation.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Implement Facade pattern | eceff7a | internal/notify/facade.go |
+| 2 | Unit tests for Facade pattern | eceff7a | internal/notify/facade_test.go |
+
+## What Was Built
+
+- `Notifier` interface with `Notify(userID, message string) error`
+- `ConsoleNotifier` struct — writes `[CONSOLE] User {id}: {msg}\n` to an `io.Writer`
+- `FileNotifier` struct — writes `[FILE] User {id}: {msg}\n` to an `io.Writer`
+- `NotificationFacade` struct — holds `[]Notifier`, iterates all notifiers on each call
+- `NewNotificationFacade(console, file io.Writer)` constructor
+- `NotifyUser(userID, message string) error` — sends through all notifiers, aggregates errors
+- `NotifyOrderStatusChanged(orderID, status string) error` — formats and delegates to NotifyUser
+
+## Decisions Made
+
+- **io.Writer for notifiers:** Both ConsoleNotifier and FileNotifier accept `io.Writer` rather than using `os.Stdout`/real files directly, enabling clean unit testing with `bytes.Buffer`.
+- **errors.Join for aggregation:** Errors from individual notifiers are collected and joined so partial failures are visible to callers (Pitfall 10 compliance — errors not swallowed).
+- **Slice of Notifier interface:** Facade holds `[]Notifier` enabling easy extension with additional channels without changing facade methods.
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Test Coverage
+
+- `TestNotifyUser_SendsToBothChannels` — verifies both console and file buffers receive `[CONSOLE]`/`[FILE]` prefixed output with userID and message
+- `TestNotifyOrderStatusChanged_FormatsMessage` — verifies orderID and status appear in output
+- `TestFacade_ErrorPropagation` — uses a `failingWriter` that returns error on Write, verifies facade returns non-nil error
+
+All 3 tests pass. Full `go test ./...` passes with no regressions.
+
+## Self-Check: PASSED
+
+- [x] `internal/notify/facade.go` exists
+- [x] `internal/notify/facade_test.go` exists
+- [x] Commit eceff7a exists and contains both files
+- [x] `go test ./internal/notify/ -v` all pass
+- [x] `go vet ./internal/notify/` no issues

--- a/.planning/phases/05-notifications-logging/05-02-PLAN.md
+++ b/.planning/phases/05-notifications-logging/05-02-PLAN.md
@@ -1,0 +1,276 @@
+---
+phase: 05-notifications-logging
+plan: 02
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - internal/logging/proxy.go
+  - internal/logging/bridge.go
+  - internal/logging/proxy_test.go
+  - internal/logging/bridge_test.go
+autonomous: true
+requirements:
+  - NOTF-04
+  - NOTF-05
+  - NOTF-06
+  - NOTF-09
+  - NOTF-10
+  - NOTF-11
+  - NOTF-13
+  - NOTF-14
+
+must_haves:
+  truths:
+    - "LoggerProxy lazily initializes FileLogger on first Log call"
+    - "LoggerProxy counts log entries via GetLogCount"
+    - "LoggerProxy filters log entries by level (info/warn/error)"
+    - "TextFormatter + ConsoleWriter produces plain text to stdout"
+    - "JSONFormatter + FileWriter produces JSON to file"
+    - "Any formatter combines with any writer"
+  artifacts:
+    - path: "internal/logging/proxy.go"
+      provides: "Logger interface, FileLogger, LoggerProxy with lazy init, counting, and level filtering"
+      exports: ["Logger", "FileLogger", "LoggerProxy", "NewLoggerProxy", "LogEntry", "GetLogCount", "GetEntries"]
+    - path: "internal/logging/bridge.go"
+      provides: "Bridge pattern — OutputWriter interface with ConsoleWriter/FileWriter, Formatter with TextFormatter/JSONFormatter"
+      exports: ["OutputWriter", "ConsoleWriter", "FileWriter", "Formatter", "TextFormatter", "JSONFormatter"]
+    - path: "internal/logging/proxy_test.go"
+      provides: "Proxy unit tests"
+    - path: "internal/logging/bridge_test.go"
+      provides: "Bridge unit tests"
+  key_links:
+    - from: "LoggerProxy"
+      to: "FileLogger"
+      via: "lazy initialization on first Log call"
+      pattern: "if.*nil.*NewFileLogger"
+    - from: "TextFormatter/JSONFormatter"
+      to: "ConsoleWriter/FileWriter"
+      via: "OutputWriter field in Formatter base"
+      pattern: "writer OutputWriter"
+---
+
+<objective>
+Implement the Proxy pattern (Logger with lazy init, counting, level filtering) and Bridge pattern (Formatter abstraction x OutputWriter implementation) in the logging package.
+
+Purpose: Demonstrate Proxy (controlled access with added behavior) and Bridge (separate abstraction from implementation so both vary independently).
+Output: internal/logging/ package with proxy.go, bridge.go, and their tests.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@TASKS.md
+@.planning/research/STACK.md
+@.planning/research/PITFALLS.md
+</context>
+
+<tasks>
+
+<task type="auto" tdd="true">
+  <name>Task 1: Implement Proxy pattern — Logger interface, FileLogger, LoggerProxy</name>
+  <files>internal/logging/proxy.go</files>
+  <read_first>
+    - TASKS.md (Issue #8 Proxy spec)
+    - .planning/research/PITFALLS.md (Pitfall 8: interface extraction for Proxy)
+    - .planning/research/STACK.md (Proxy section)
+  </read_first>
+  <behavior>
+    - LoggerProxy.Log("info", "test") creates FileLogger on first call (lazy init)
+    - LoggerProxy.Log("info", "msg") increments log count; GetLogCount returns count
+    - LoggerProxy configured with minLevel="warn" skips "info" entries
+    - LoggerProxy stores entries in-memory for API retrieval (GetEntries returns []LogEntry)
+    - GetEntries with level filter returns only matching entries
+  </behavior>
+  <action>
+Create `internal/logging/proxy.go` with:
+
+1. `LogEntry` struct with `Level string`, `Message string`, `Timestamp string` fields (json tags: `"level"`, `"message"`, `"timestamp"`).
+
+2. `Logger` interface with `Log(level, message string)` method.
+
+3. `FileLogger` struct with `writer io.Writer` field. Constructor `NewFileLogger(w io.Writer) *FileLogger`. Method `Log(level, message string)` writes formatted line like `[LEVEL] message\n` to writer. FileLogger implements Logger.
+
+4. `LoggerProxy` struct with fields:
+   - `realLogger Logger` (nil until first use — lazy init)
+   - `writer io.Writer` (passed to FileLogger when created)
+   - `minLevel string` (minimum level to log: "info" < "warn" < "error")
+   - `entries []LogEntry` (in-memory store for API access)
+   - `logCount int`
+
+5. `NewLoggerProxy(w io.Writer, minLevel string) *LoggerProxy` constructor. Sets minLevel, stores writer, leaves realLogger nil.
+
+6. `Log(level, message string)` method on LoggerProxy:
+   - Check level against minLevel using a helper `levelValue(level string) int` that maps info=0, warn=1, error=2. If levelValue(level) < levelValue(minLevel), return (skip).
+   - If `realLogger == nil`, create it: `p.realLogger = NewFileLogger(p.writer)` (lazy init).
+   - Delegate to `p.realLogger.Log(level, message)`.
+   - Append LogEntry to `p.entries` with current timestamp (use `time.Now().Format(time.RFC3339)`).
+   - Increment `p.logCount`.
+
+7. `GetLogCount() int` — returns p.logCount.
+
+8. `GetEntries(level string) []LogEntry` — if level is empty, return all entries. Otherwise filter by matching level.
+
+LoggerProxy implements Logger interface. Follow project conventions: single-letter receivers (`p` for proxy, `l` for logger), PascalCase exports, Ukrainian doc comments.
+  </action>
+  <acceptance_criteria>
+    - grep -q "type Logger interface" internal/logging/proxy.go
+    - grep -q "type FileLogger struct" internal/logging/proxy.go
+    - grep -q "type LoggerProxy struct" internal/logging/proxy.go
+    - grep -q "type LogEntry struct" internal/logging/proxy.go
+    - grep -q "func (p \*LoggerProxy) Log" internal/logging/proxy.go
+    - grep -q "func (p \*LoggerProxy) GetLogCount" internal/logging/proxy.go
+    - grep -q "func (p \*LoggerProxy) GetEntries" internal/logging/proxy.go
+    - grep -q "realLogger" internal/logging/proxy.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go build ./internal/logging/...</automated>
+  </verify>
+  <done>Logger interface, FileLogger, and LoggerProxy all exist. Proxy has lazy init, log counting, level filtering, and in-memory entry storage.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: Implement Bridge pattern — OutputWriter + Formatter abstractions</name>
+  <files>internal/logging/bridge.go</files>
+  <read_first>
+    - TASKS.md (Issue #8 Bridge spec)
+    - .planning/research/STACK.md (Bridge section)
+    - .planning/research/PITFALLS.md (Pitfall 11: abstraction/implementor confusion)
+  </read_first>
+  <behavior>
+    - TextFormatter with ConsoleWriter formats as plain text to stdout writer
+    - JSONFormatter with ConsoleWriter formats as JSON to stdout writer
+    - TextFormatter with FileWriter formats as plain text to file writer
+    - JSONFormatter with FileWriter formats as JSON to file writer
+    - Any Formatter + any Writer combination works
+  </behavior>
+  <action>
+Create `internal/logging/bridge.go` with:
+
+1. `OutputWriter` interface (implementor) with `Write(data string) error` method.
+
+2. `ConsoleWriter` struct with `writer io.Writer` field (defaults to os.Stdout, configurable for testing). Constructor `NewConsoleWriter(w io.Writer) *ConsoleWriter`. Method `Write(data string) error` writes data to writer.
+
+3. `FileWriter` struct with `writer io.Writer` field. Constructor `NewFileWriter(w io.Writer) *FileWriter`. Method `Write(data string) error` writes data to writer.
+
+4. `Formatter` struct (base abstraction) with `writer OutputWriter` field. This is the Bridge — holds a reference to the implementor.
+
+5. `TextFormatter` struct embedding `Formatter`. Constructor `NewTextFormatter(w OutputWriter) *TextFormatter`. Method `Format(level, message string) error`:
+   - Formats as plain text: `[LEVEL] message\n`
+   - Calls `f.writer.Write(formatted)` and returns result.
+
+6. `JSONFormatter` struct embedding `Formatter`. Constructor `NewJSONFormatter(w OutputWriter) *JSONFormatter`. Method `Format(level, message string) error`:
+   - Formats as JSON: `{"level":"LEVEL","message":"message"}\n` (use fmt.Sprintf, no encoding/json needed for this simple case)
+   - Calls `f.writer.Write(formatted)` and returns result.
+
+The two axes of variation are explicit: Formatter (TextFormatter/JSONFormatter) x OutputWriter (ConsoleWriter/FileWriter). Per Pitfall 11, name each layer with distinct responsibility — Formatter is "what format", OutputWriter is "where to write".
+  </action>
+  <acceptance_criteria>
+    - grep -q "type OutputWriter interface" internal/logging/bridge.go
+    - grep -q "type ConsoleWriter struct" internal/logging/bridge.go
+    - grep -q "type FileWriter struct" internal/logging/bridge.go
+    - grep -q "type Formatter struct" internal/logging/bridge.go
+    - grep -q "type TextFormatter struct" internal/logging/bridge.go
+    - grep -q "type JSONFormatter struct" internal/logging/bridge.go
+    - grep -q "writer OutputWriter" internal/logging/bridge.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go build ./internal/logging/...</automated>
+  </verify>
+  <done>Bridge pattern implemented with OutputWriter interface (ConsoleWriter, FileWriter) and Formatter abstraction (TextFormatter, JSONFormatter). Any formatter combines with any writer.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 3: Unit tests for Proxy and Bridge patterns</name>
+  <files>internal/logging/proxy_test.go, internal/logging/bridge_test.go</files>
+  <read_first>
+    - internal/logging/proxy.go (just created)
+    - internal/logging/bridge.go (just created)
+    - internal/discount/command_test.go (test style reference)
+  </read_first>
+  <behavior>
+    - Proxy tests: lazy init verified (realLogger nil before first Log), counter increments, level filtering skips lower levels, GetEntries returns stored entries, GetEntries with level filter works
+    - Bridge tests: all 4 combinations (Text+Console, Text+File, JSON+Console, JSON+File) produce correct output
+  </behavior>
+  <action>
+Create `internal/logging/proxy_test.go` with:
+
+1. `TestLoggerProxy_LazyInit` — create proxy with bytes.Buffer, verify that before calling Log the real logger is not initialized (call GetLogCount, assert 0), then call Log("info", "test"), assert GetLogCount == 1.
+
+2. `TestLoggerProxy_CountsLogs` — log 3 messages, assert GetLogCount == 3.
+
+3. `TestLoggerProxy_LevelFiltering` — create proxy with minLevel="warn". Log info (should be skipped), warn (should pass), error (should pass). Assert GetLogCount == 2. Assert buffer does not contain the info message.
+
+4. `TestLoggerProxy_GetEntries` — log several messages at different levels, call GetEntries("error"), verify only error entries returned. Call GetEntries("") to get all.
+
+5. `TestLoggerProxy_WritesToRealLogger` — create proxy with bytes.Buffer, log a message, assert buffer contains the message text.
+
+Create `internal/logging/bridge_test.go` with:
+
+1. `TestBridge_AllCombinations` — table-driven test with 4 cases:
+   - TextFormatter + ConsoleWriter: assert output contains `[INFO] test message`
+   - TextFormatter + FileWriter: assert output contains `[INFO] test message`
+   - JSONFormatter + ConsoleWriter: assert output contains `"level":"INFO"`
+   - JSONFormatter + FileWriter: assert output contains `"message":"test message"`
+
+   Each case: create a bytes.Buffer, create the writer with that buffer, create the formatter with that writer, call Format("INFO", "test message"), assert buffer content.
+
+2. `TestBridge_JSONFormat` — verify JSONFormatter output is valid-looking JSON (contains `{` and `}`).
+
+3. `TestBridge_TextFormat` — verify TextFormatter output has bracket-level format.
+
+Use bytes.Buffer for all writers. Follow project test conventions.
+  </action>
+  <acceptance_criteria>
+    - grep -q "TestLoggerProxy_LazyInit" internal/logging/proxy_test.go
+    - grep -q "TestLoggerProxy_LevelFiltering" internal/logging/proxy_test.go
+    - grep -q "TestLoggerProxy_GetEntries" internal/logging/proxy_test.go
+    - grep -q "TestBridge_AllCombinations" internal/logging/bridge_test.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go test ./internal/logging/ -v -count=1</automated>
+  </verify>
+  <done>All Proxy tests pass (lazy init, counting, level filtering, entry retrieval). All Bridge tests pass (4 formatter+writer combinations verified).</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| N/A | Internal logging domain; no external input in this plan |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation |
+|-----------|----------|-----------|-------------|------------|
+| T-05-03 | D (DoS) | LoggerProxy in-memory entries grow unbounded | accept | Educational project; no long-running production use |
+| T-05-04 | I (Info Disclosure) | Log entries stored in memory | accept | No sensitive data in educational context |
+</threat_model>
+
+<verification>
+- `go test ./internal/logging/ -v` passes all tests
+- `go vet ./internal/logging/` reports no issues
+- `go build ./internal/logging/` compiles cleanly
+</verification>
+
+<success_criteria>
+- LoggerProxy lazily creates FileLogger on first Log call
+- LoggerProxy counts entries and supports GetLogCount
+- LoggerProxy filters by level (info < warn < error)
+- LoggerProxy stores entries for retrieval via GetEntries
+- Bridge: TextFormatter and JSONFormatter each work with ConsoleWriter and FileWriter
+- All unit tests pass for both Proxy and Bridge
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-notifications-logging/05-02-SUMMARY.md`
+</output>

--- a/.planning/phases/05-notifications-logging/05-02-SUMMARY.md
+++ b/.planning/phases/05-notifications-logging/05-02-SUMMARY.md
@@ -1,0 +1,116 @@
+---
+phase: 05-notifications-logging
+plan: 02
+subsystem: logging
+tags: [proxy, bridge, go, logging, design-patterns]
+dependency_graph:
+  requires: []
+  provides: [logging.Logger, logging.LoggerProxy, logging.FileLogger, logging.LogEntry, logging.OutputWriter, logging.ConsoleWriter, logging.FileWriter, logging.Formatter, logging.TextFormatter, logging.JSONFormatter]
+  affects: []
+tech_stack:
+  added: []
+  patterns: [Proxy, Bridge]
+key_files:
+  created:
+    - internal/logging/proxy.go
+    - internal/logging/proxy_test.go
+    - internal/logging/bridge.go
+    - internal/logging/bridge_test.go
+  modified: []
+decisions:
+  - Use fmt.Sprintf with %q verb for JSON formatting to avoid encoding/json dependency (stdlib only constraint)
+  - levelValue helper maps info=0/warn=1/error=2 for simple comparison-based level filtering
+  - ConsoleWriter accepts io.Writer parameter for testability, defaults to os.Stdout if nil
+  - TDD approach: tests written before implementation for both patterns
+metrics:
+  duration: ~15 minutes
+  completed: 2026-04-07T22:33:42Z
+  tasks_completed: 3
+  tasks_total: 3
+  files_changed: 4
+---
+
+# Phase 05 Plan 02: Proxy and Bridge Logging Patterns Summary
+
+**One-liner:** Proxy pattern (LoggerProxy with lazy FileLogger init, counting, level filtering) and Bridge pattern (TextFormatter/JSONFormatter × ConsoleWriter/FileWriter) for the logging package.
+
+## What Was Built
+
+### Task 1: Proxy Pattern (proxy.go + proxy_test.go)
+
+Commit `6013444`
+
+- `LogEntry` struct with JSON tags (`level`, `message`, `timestamp`)
+- `Logger` interface with `Log(level, message string)` — the Proxy's subject interface
+- `FileLogger` struct — real subject, writes `[LEVEL] message\n` to `io.Writer`
+- `LoggerProxy` struct — proxy with lazy init, level filtering, log counting, in-memory entry storage
+- `NewLoggerProxy(w io.Writer, minLevel string)` — leaves `realLogger` nil until first eligible Log call
+- `levelValue()` helper maps info=0, warn=1, error=2 for level comparison
+- `GetLogCount() int` and `GetEntries(level string) []LogEntry` accessors
+- 5 unit tests covering: lazy init, counting, level filtering, entry retrieval, delegation to real logger
+
+### Task 2: Bridge Pattern (bridge.go + bridge_test.go)
+
+Commit `14c5afc`
+
+- `OutputWriter` interface (implementor axis): `Write(data string) error`
+- `ConsoleWriter` — writes to `io.Writer` (os.Stdout or injected buffer for tests)
+- `FileWriter` — writes to `io.Writer`
+- `Formatter` struct (abstraction base) — holds `writer OutputWriter` field (the bridge link)
+- `TextFormatter` (embeds Formatter) — formats as `[LEVEL] message\n`
+- `JSONFormatter` (embeds Formatter) — formats as `{"level":"...","message":"..."}\n`
+- 3 test functions covering: all 4 formatter×writer combinations, JSON brace validation, text bracket validation
+
+### Task 3: Unit Tests (TDD — written as part of Tasks 1 and 2)
+
+Tests were written first (failing/RED), then implementations made them pass (GREEN), following TDD protocol. All 8 tests pass:
+- `TestLoggerProxy_LazyInit`
+- `TestLoggerProxy_CountsLogs`
+- `TestLoggerProxy_LevelFiltering`
+- `TestLoggerProxy_GetEntries`
+- `TestLoggerProxy_WritesToRealLogger`
+- `TestBridge_AllCombinations` (table-driven, 4 subtests)
+- `TestBridge_JSONFormat`
+- `TestBridge_TextFormat`
+
+## Pattern Demonstration
+
+### Proxy Pattern
+`LoggerProxy` wraps `FileLogger` (the real subject) behind the `Logger` interface. The proxy adds three behaviors without modifying the real logger: (1) lazy initialization — `FileLogger` is created only on the first `Log` call that passes the level filter; (2) call counting via `logCount`; (3) level filtering that skips `Log` calls below `minLevel`.
+
+### Bridge Pattern
+Two independent axes vary independently:
+- **Abstraction axis** (what format): `TextFormatter` and `JSONFormatter`
+- **Implementor axis** (where to write): `ConsoleWriter` and `FileWriter`
+
+The `Formatter` base struct holds an `OutputWriter` field — this is the bridge. Swapping either axis does not require changing the other, yielding 4 combinations from 2 abstractions × 2 implementors.
+
+## Verification Results
+
+```
+go vet ./internal/logging/    → no issues
+go build ./internal/logging/  → compiles cleanly
+go test ./internal/logging/ -v → PASS (8/8 tests)
+go test ./...                  → all packages pass
+```
+
+## Deviations from Plan
+
+None — plan executed exactly as written. TDD protocol followed for all three tasks (RED → GREEN for each).
+
+## Known Stubs
+
+None — all implementations are fully wired. No placeholder data or mock returns.
+
+## Threat Flags
+
+None — this is an internal logging domain with no external input surface. Threat register items T-05-03 and T-05-04 (accepted) apply: unbounded in-memory entries and log entry storage are educational-context accepted risks.
+
+## Self-Check: PASSED
+
+- `internal/logging/proxy.go` — FOUND
+- `internal/logging/proxy_test.go` — FOUND
+- `internal/logging/bridge.go` — FOUND
+- `internal/logging/bridge_test.go` — FOUND
+- Commit `6013444` — FOUND (Task 1)
+- Commit `14c5afc` — FOUND (Task 2)

--- a/.planning/phases/05-notifications-logging/05-03-PLAN.md
+++ b/.planning/phases/05-notifications-logging/05-03-PLAN.md
@@ -1,0 +1,257 @@
+---
+phase: 05-notifications-logging
+plan: 03
+type: execute
+wave: 2
+depends_on:
+  - 05-01
+  - 05-02
+files_modified:
+  - internal/handler/notifications.go
+  - internal/handler/notifications_test.go
+  - cmd/server/main.go
+autonomous: true
+requirements:
+  - NOTF-03
+  - NOTF-07
+  - NOTF-08
+  - NOTF-15
+
+must_haves:
+  truths:
+    - "POST /api/notifications/send triggers NotifyUser via Facade"
+    - "GET /api/logs?level=error returns filtered log entries as JSON"
+    - "GET /api/logs/stats returns log counts by level as JSON"
+    - "All three endpoints registered in main.go"
+  artifacts:
+    - path: "internal/handler/notifications.go"
+      provides: "HTTP handlers for notification and logging endpoints"
+      exports: ["NotificationHandler", "NewNotificationHandler", "HandleNotify", "HandleLogs", "HandleLogStats"]
+    - path: "internal/handler/notifications_test.go"
+      provides: "Handler tests via httptest"
+    - path: "cmd/server/main.go"
+      provides: "Route registration for all 3 endpoints"
+      contains: "notificationHandler"
+  key_links:
+    - from: "internal/handler/notifications.go"
+      to: "internal/notify"
+      via: "import — handler uses NotificationFacade"
+      pattern: "notify\\.NotificationFacade"
+    - from: "internal/handler/notifications.go"
+      to: "internal/logging"
+      via: "import — handler uses LoggerProxy"
+      pattern: "logging\\.LoggerProxy"
+    - from: "cmd/server/main.go"
+      to: "internal/handler/notifications.go"
+      via: "route registration"
+      pattern: "notificationHandler"
+---
+
+<objective>
+Wire up HTTP handlers for notification sending, log retrieval, and log stats. Register all routes in main.go.
+
+Purpose: Connect Facade and Proxy/Bridge patterns to REST endpoints, completing the feature.
+Output: Handler file with tests, updated main.go with routes.
+</objective>
+
+<execution_context>
+@$HOME/.claude/get-shit-done/workflows/execute-plan.md
+@$HOME/.claude/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@TASKS.md
+@cmd/server/main.go
+@.planning/phases/05-notifications-logging/05-01-SUMMARY.md
+@.planning/phases/05-notifications-logging/05-02-SUMMARY.md
+</context>
+
+<interfaces>
+<!-- Key types from Plan 01 and Plan 02 that this plan depends on -->
+
+From internal/notify/facade.go (Plan 01):
+```go
+type Notifier interface {
+    Notify(userID, message string) error
+}
+type NotificationFacade struct { ... }
+func NewNotificationFacade(console io.Writer, file io.Writer) *NotificationFacade
+func (f *NotificationFacade) NotifyUser(userID, message string) error
+func (f *NotificationFacade) NotifyOrderStatusChanged(orderID, status string) error
+```
+
+From internal/logging/proxy.go (Plan 02):
+```go
+type Logger interface {
+    Log(level, message string)
+}
+type LogEntry struct {
+    Level   string `json:"level"`
+    Message string `json:"message"`
+    Timestamp string `json:"timestamp"`
+}
+type LoggerProxy struct { ... }
+func NewLoggerProxy(w io.Writer, minLevel string) *LoggerProxy
+func (p *LoggerProxy) Log(level, message string)
+func (p *LoggerProxy) GetLogCount() int
+func (p *LoggerProxy) GetEntries(level string) []LogEntry
+```
+</interfaces>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Implement HTTP handlers for notifications and logging endpoints</name>
+  <files>internal/handler/notifications.go, cmd/server/main.go</files>
+  <read_first>
+    - internal/handler/discounts.go (handler pattern reference)
+    - internal/handler/products.go (handler pattern reference)
+    - internal/notify/facade.go (Plan 01 output — actual exports)
+    - internal/logging/proxy.go (Plan 02 output — actual exports)
+    - cmd/server/main.go (current routes)
+  </read_first>
+  <action>
+Create `internal/handler/notifications.go` with:
+
+1. `NotificationHandler` struct with fields:
+   - `facade *notify.NotificationFacade`
+   - `logger *logging.LoggerProxy`
+
+2. `NewNotificationHandler() *NotificationHandler` constructor:
+   - Create NotificationFacade with `os.Stdout` for console and `os.Stdout` for file (educational — both go to stdout in this demo, or use a bytes.Buffer for file if preferred).
+   - Create LoggerProxy with `os.Stdout` writer and minLevel `"info"`.
+   - Log a startup message: `logger.Log("info", "Notification handler initialized")`.
+
+3. `HandleNotify(w http.ResponseWriter, r *http.Request)`:
+   - Only accept POST. Return 405 for other methods.
+   - Decode JSON body: `{"user_id": string, "message": string}`.
+   - Validate user_id and message are non-empty, return 400 if missing.
+   - Call `h.facade.NotifyUser(userID, message)`.
+   - Also log via proxy: `h.logger.Log("info", fmt.Sprintf("Notification sent to %s", userID))`.
+   - If error from facade, return 500. Otherwise return 200 with `{"status": "sent"}`.
+
+4. `HandleLogs(w http.ResponseWriter, r *http.Request)`:
+   - Only accept GET. Return 405 for other methods.
+   - Read `level` query param from `r.URL.Query().Get("level")`.
+   - Call `h.logger.GetEntries(level)` to get filtered entries.
+   - Return 200 with JSON array of entries.
+
+5. `HandleLogStats(w http.ResponseWriter, r *http.Request)`:
+   - Only accept GET. Return 405 for other methods.
+   - Get all entries via `h.logger.GetEntries("")`.
+   - Count by level: iterate entries, build `map[string]int` of level counts.
+   - Also include `"total": h.logger.GetLogCount()`.
+   - Return 200 with JSON object like `{"info": 5, "warn": 2, "error": 1, "total": 8}`.
+
+Update `cmd/server/main.go`:
+   - Add `notificationHandler := handler.NewNotificationHandler()` after existing handler inits.
+   - Register routes:
+     - `http.HandleFunc("/api/notifications/send", notificationHandler.HandleNotify)`
+     - `http.HandleFunc("/api/logs", notificationHandler.HandleLogs)`
+     - `http.HandleFunc("/api/logs/stats", notificationHandler.HandleLogStats)`
+
+Follow existing handler conventions: method check first, json.NewDecoder for body, json.NewEncoder for response, set Content-Type header.
+  </action>
+  <acceptance_criteria>
+    - grep -q "type NotificationHandler struct" internal/handler/notifications.go
+    - grep -q "func (h \*NotificationHandler) HandleNotify" internal/handler/notifications.go
+    - grep -q "func (h \*NotificationHandler) HandleLogs" internal/handler/notifications.go
+    - grep -q "func (h \*NotificationHandler) HandleLogStats" internal/handler/notifications.go
+    - grep -q "notificationHandler" cmd/server/main.go
+    - grep -q "/api/notifications/send" cmd/server/main.go
+    - grep -q "/api/logs" cmd/server/main.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go build ./...</automated>
+  </verify>
+  <done>All three handlers exist. Routes registered in main.go. Project compiles cleanly.</done>
+</task>
+
+<task type="auto" tdd="true">
+  <name>Task 2: HTTP handler tests for notification and logging endpoints</name>
+  <files>internal/handler/notifications_test.go</files>
+  <read_first>
+    - internal/handler/notifications.go (just created)
+    - internal/handler/discounts_test.go (test pattern reference)
+    - internal/handler/products_test.go (test pattern reference)
+  </read_first>
+  <behavior>
+    - POST /api/notifications/send with valid body returns 200
+    - POST /api/notifications/send with missing fields returns 400
+    - GET /api/notifications/send returns 405
+    - GET /api/logs returns JSON array of log entries
+    - GET /api/logs?level=error returns only error entries
+    - GET /api/logs/stats returns counts by level with total
+  </behavior>
+  <action>
+Create `internal/handler/notifications_test.go` with:
+
+1. `TestHandleNotify_Success` — POST with `{"user_id":"u1","message":"hello"}`, assert 200, decode response, check `status == "sent"`.
+
+2. `TestHandleNotify_MissingFields` — POST with `{"user_id":""}` or missing message, assert 400.
+
+3. `TestHandleNotify_WrongMethod` — send GET to HandleNotify, assert 405.
+
+4. `TestHandleLogs_ReturnsEntries` — first send a notification (to generate a log entry), then GET /api/logs, assert 200, decode JSON array, assert len > 0.
+
+5. `TestHandleLogs_FilterByLevel` — send notifications to generate entries, GET /api/logs?level=info, assert all returned entries have level "info".
+
+6. `TestHandleLogStats_ReturnsCounts` — send notifications to generate entries, GET /api/logs/stats, assert 200, decode JSON object, verify "total" key exists and is > 0.
+
+Use `httptest.NewRecorder()` and `httptest.NewRequest()`. Create a shared `NotificationHandler` instance for tests that need accumulated state (logs). Follow existing handler test patterns from discounts_test.go.
+  </action>
+  <acceptance_criteria>
+    - grep -q "TestHandleNotify_Success" internal/handler/notifications_test.go
+    - grep -q "TestHandleNotify_MissingFields" internal/handler/notifications_test.go
+    - grep -q "TestHandleLogs" internal/handler/notifications_test.go
+    - grep -q "TestHandleLogStats" internal/handler/notifications_test.go
+  </acceptance_criteria>
+  <verify>
+    <automated>cd /Users/r2d2/university/semester2_2026/OOP/paw-shop && go test ./internal/handler/ -run TestHandleNotify -v -count=1 && go test ./internal/handler/ -run TestHandleLogs -v -count=1</automated>
+  </verify>
+  <done>All handler tests pass. POST /api/notifications/send, GET /api/logs, and GET /api/logs/stats are tested for success, error, and edge cases.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| client -> API | Untrusted JSON input from POST /api/notifications/send |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Disposition | Mitigation |
+|-----------|----------|-----------|-------------|------------|
+| T-05-05 | S (Spoofing) | user_id in notification request | accept | No auth in educational project per constraints |
+| T-05-06 | T (Tampering) | POST body manipulation | mitigate | Validate required fields non-empty, return 400 on bad input |
+| T-05-07 | D (DoS) | Unbounded log entry accumulation via repeated POSTs | accept | Educational project; in-memory only |
+</threat_model>
+
+<verification>
+- `go test ./... -count=1` — all tests pass (existing + new)
+- `go vet ./...` — no issues
+- `go build ./...` — compiles cleanly
+- Server starts and endpoints respond:
+  - `curl -X POST localhost:8080/api/notifications/send -d '{"user_id":"u1","message":"test"}'` returns 200
+  - `curl localhost:8080/api/logs` returns JSON array
+  - `curl localhost:8080/api/logs/stats` returns JSON object with counts
+</verification>
+
+<success_criteria>
+- POST /api/notifications/send triggers NotifyUser via Facade, returns 200
+- GET /api/logs?level=X returns filtered entries from LoggerProxy
+- GET /api/logs/stats returns level counts
+- All handler tests pass
+- All existing tests still pass
+- Routes registered in main.go
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/05-notifications-logging/05-03-SUMMARY.md`
+</output>

--- a/.planning/phases/05-notifications-logging/05-03-SUMMARY.md
+++ b/.planning/phases/05-notifications-logging/05-03-SUMMARY.md
@@ -1,0 +1,95 @@
+---
+phase: 05-notifications-logging
+plan: "03"
+subsystem: handler
+tags: [facade, proxy, bridge, http-handler, rest-api, logging]
+dependency_graph:
+  requires: [05-01, 05-02]
+  provides: [notification-endpoints, log-endpoints]
+  affects: [cmd/server/main.go]
+tech_stack:
+  added: []
+  patterns: [facade-consumer, proxy-consumer, http-handler]
+key_files:
+  created:
+    - internal/handler/notifications.go
+    - internal/handler/notifications_test.go
+  modified:
+    - cmd/server/main.go
+decisions:
+  - Both console and file writers point to os.Stdout in educational demo (per plan spec)
+  - Log stats counts computed per-level by iterating GetEntries("") result
+metrics:
+  duration: "~10 minutes"
+  completed: "2026-04-07T22:36:08Z"
+  tasks_completed: 2
+  tasks_total: 2
+  files_created: 2
+  files_modified: 1
+---
+
+# Phase 05 Plan 03: HTTP Handlers for Notifications and Logging Summary
+
+HTTP handlers wiring NotificationFacade and LoggerProxy to REST endpoints — POST /api/notifications/send, GET /api/logs, GET /api/logs/stats — with full httptest coverage.
+
+## Tasks Completed
+
+| Task | Name | Commit | Files |
+|------|------|--------|-------|
+| 1 | Implement HTTP handlers for notifications and logging endpoints | f1ada40 | internal/handler/notifications.go, cmd/server/main.go |
+| 2 | HTTP handler tests for notification and logging endpoints | f8aecd9 | internal/handler/notifications_test.go |
+
+## What Was Built
+
+### NotificationHandler (internal/handler/notifications.go)
+
+Struct holding `*notify.NotificationFacade` and `*logging.LoggerProxy`. Three HTTP handlers:
+
+- `HandleNotify` — POST only; decodes `{user_id, message}`, validates non-empty, calls `facade.NotifyUser()`, logs via proxy, returns `{"status":"sent"}`.
+- `HandleLogs` — GET only; reads `level` query param, delegates to `proxy.GetEntries(level)`, returns JSON array.
+- `HandleLogStats` — GET only; counts entries per level from `proxy.GetEntries("")`, adds `"total"` from `proxy.GetLogCount()`, returns JSON object.
+
+### Route Registration (cmd/server/main.go)
+
+Three routes added after existing handler inits:
+- `POST /api/notifications/send`
+- `GET /api/logs`
+- `GET /api/logs/stats`
+
+### Tests (internal/handler/notifications_test.go)
+
+Six tests using `httptest.NewRecorder` / `httptest.NewRequest`:
+- `TestHandleNotify_Success` — 200 + `{"status":"sent"}`
+- `TestHandleNotify_MissingFields` — 400 on empty user_id
+- `TestHandleNotify_WrongMethod` — 405 on GET
+- `TestHandleLogs_ReturnsEntries` — 200 + non-empty JSON array after notify
+- `TestHandleLogs_FilterByLevel` — all returned entries have level "info"
+- `TestHandleLogStats_ReturnsCounts` — 200 + "total" > 0
+
+## Deviations from Plan
+
+None — plan executed exactly as written.
+
+## Known Stubs
+
+None. All three endpoints are fully wired to live Facade and Proxy instances.
+
+## Threat Surface Scan
+
+| Flag | File | Description |
+|------|------|-------------|
+| T-05-06 mitigated | internal/handler/notifications.go | POST body validated: user_id and message checked non-empty, returns 400 on missing fields |
+
+No new unplanned threat surface introduced.
+
+## Self-Check: PASSED
+
+Files exist:
+- internal/handler/notifications.go: FOUND
+- internal/handler/notifications_test.go: FOUND
+
+Commits exist:
+- f1ada40: feat(05-03): implement HTTP handlers for notifications and logging endpoints
+- f8aecd9: test(05-03): add HTTP handler tests for notification and logging endpoints
+
+All 6 new tests pass. Full test suite (13 packages) passes cleanly. `go vet ./...` reports no issues.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ func main() {
 	searchHandler := handler.NewSearchHandler()
 	chatHandler := handler.NewChatHandler()
 	cartHandler := handler.NewCartHandler()
+	notificationHandler := handler.NewNotificationHandler()
 
 	http.Handle("/", http.FileServer(http.Dir("./static")))
 	http.HandleFunc("/api/products", productHandler.HandleProducts)
@@ -32,6 +33,9 @@ func main() {
 	http.HandleFunc("/api/chat/", chatHandler.HandleChat)
 	http.HandleFunc("/api/cart", cartHandler.HandleCart)
 	http.HandleFunc("/api/cart/", cartHandler.HandleCart)
+	http.HandleFunc("/api/notifications/send", notificationHandler.HandleNotify)
+	http.HandleFunc("/api/logs", notificationHandler.HandleLogs)
+	http.HandleFunc("/api/logs/stats", notificationHandler.HandleLogStats)
 
 	port := ":8080"
 	fmt.Printf("PawShop server starting on http://localhost%s\n", port)

--- a/internal/handler/notifications.go
+++ b/internal/handler/notifications.go
@@ -1,0 +1,101 @@
+// Package handler — HTTP-обробники для нотифікацій та логування.
+// Патерни: Facade (notify.NotificationFacade), Proxy (logging.LoggerProxy), Bridge (logging).
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/illia-malachyn/paw-shop/internal/logging"
+	"github.com/illia-malachyn/paw-shop/internal/notify"
+)
+
+// NotificationHandler — обробник HTTP-запитів для нотифікацій та логів.
+// Використовує NotificationFacade (Facade pattern) та LoggerProxy (Proxy pattern).
+type NotificationHandler struct {
+	facade *notify.NotificationFacade
+	logger *logging.LoggerProxy
+}
+
+// NewNotificationHandler — конструктор NotificationHandler.
+// Ініціалізує Facade та Proxy з виводом у os.Stdout.
+func NewNotificationHandler() *NotificationHandler {
+	facade := notify.NewNotificationFacade(os.Stdout, os.Stdout)
+	logger := logging.NewLoggerProxy(os.Stdout, "info")
+	logger.Log("info", "Notification handler initialized")
+
+	return &NotificationHandler{
+		facade: facade,
+		logger: logger,
+	}
+}
+
+// HandleNotify — POST /api/notifications/send
+// Відправляє нотифікацію користувачу через Facade.
+func (h *NotificationHandler) HandleNotify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		UserID  string `json:"user_id"`
+		Message string `json:"message"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid JSON", http.StatusBadRequest)
+		return
+	}
+
+	if req.UserID == "" || req.Message == "" {
+		http.Error(w, "user_id and message are required", http.StatusBadRequest)
+		return
+	}
+
+	if err := h.facade.NotifyUser(req.UserID, req.Message); err != nil {
+		http.Error(w, "Failed to send notification", http.StatusInternalServerError)
+		return
+	}
+
+	h.logger.Log("info", fmt.Sprintf("Notification sent to %s", req.UserID))
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "sent"})
+}
+
+// HandleLogs — GET /api/logs
+// Повертає записи логу, відфільтровані за рівнем (query param: level).
+func (h *NotificationHandler) HandleLogs(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	level := r.URL.Query().Get("level")
+	entries := h.logger.GetEntries(level)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(entries)
+}
+
+// HandleLogStats — GET /api/logs/stats
+// Повертає кількість записів за рівнями та загальну кількість.
+func (h *NotificationHandler) HandleLogStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	entries := h.logger.GetEntries("")
+	counts := map[string]int{}
+	for _, e := range entries {
+		counts[e.Level]++
+	}
+	counts["total"] = h.logger.GetLogCount()
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(counts)
+}

--- a/internal/handler/notifications_test.go
+++ b/internal/handler/notifications_test.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleNotify_Success(t *testing.T) {
+	h := NewNotificationHandler()
+
+	body := `{"user_id":"u1","message":"hello"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/notifications/send", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	h.HandleNotify(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var resp map[string]string
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	if resp["status"] != "sent" {
+		t.Errorf("expected status 'sent', got '%s'", resp["status"])
+	}
+}
+
+func TestHandleNotify_MissingFields(t *testing.T) {
+	h := NewNotificationHandler()
+
+	body := `{"user_id":""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/notifications/send", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	h.HandleNotify(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleNotify_WrongMethod(t *testing.T) {
+	h := NewNotificationHandler()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/notifications/send", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleNotify(w, req)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Errorf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestHandleLogs_ReturnsEntries(t *testing.T) {
+	h := NewNotificationHandler()
+
+	// Надсилаємо нотифікацію, щоб згенерувати запис у лозі
+	notifyBody := `{"user_id":"u1","message":"hello"}`
+	notifyReq := httptest.NewRequest(http.MethodPost, "/api/notifications/send", bytes.NewBufferString(notifyBody))
+	notifyW := httptest.NewRecorder()
+	h.HandleNotify(notifyW, notifyReq)
+
+	// Отримуємо всі записи логу
+	req := httptest.NewRequest(http.MethodGet, "/api/logs", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var entries []map[string]string
+	json.NewDecoder(w.Body).Decode(&entries)
+
+	if len(entries) == 0 {
+		t.Error("expected at least one log entry, got 0")
+	}
+}
+
+func TestHandleLogs_FilterByLevel(t *testing.T) {
+	h := NewNotificationHandler()
+
+	// Надсилаємо кілька нотифікацій для генерації записів
+	notifyBody := `{"user_id":"u2","message":"test"}`
+	notifyReq := httptest.NewRequest(http.MethodPost, "/api/notifications/send", bytes.NewBufferString(notifyBody))
+	h.HandleNotify(httptest.NewRecorder(), notifyReq)
+
+	// Запит із фільтром level=info
+	req := httptest.NewRequest(http.MethodGet, "/api/logs?level=info", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogs(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var entries []map[string]string
+	json.NewDecoder(w.Body).Decode(&entries)
+
+	for _, e := range entries {
+		if e["level"] != "info" {
+			t.Errorf("expected all entries to have level 'info', got '%s'", e["level"])
+		}
+	}
+}
+
+func TestHandleLogStats_ReturnsCounts(t *testing.T) {
+	h := NewNotificationHandler()
+
+	// Надсилаємо нотифікацію для генерації записів
+	notifyBody := `{"user_id":"u3","message":"stats test"}`
+	notifyReq := httptest.NewRequest(http.MethodPost, "/api/notifications/send", bytes.NewBufferString(notifyBody))
+	h.HandleNotify(httptest.NewRecorder(), notifyReq)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/logs/stats", nil)
+	w := httptest.NewRecorder()
+
+	h.HandleLogStats(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	var stats map[string]int
+	json.NewDecoder(w.Body).Decode(&stats)
+
+	total, ok := stats["total"]
+	if !ok {
+		t.Fatal("expected 'total' key in stats response")
+	}
+	if total == 0 {
+		t.Error("expected total > 0")
+	}
+}

--- a/internal/logging/bridge.go
+++ b/internal/logging/bridge.go
@@ -1,0 +1,89 @@
+// Package logging — Bridge патерн для форматування та виводу логів.
+// Bridge: Formatter (абстракція: що формат) × OutputWriter (реалізація: куди писати).
+// Будь-який Formatter можна скомбінувати з будь-яким OutputWriter.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// OutputWriter — інтерфейс реалізатора (implementor) у патерні Bridge.
+// Визначає куди виводити дані. Реалізації: ConsoleWriter, FileWriter.
+type OutputWriter interface {
+	Write(data string) error
+}
+
+// ConsoleWriter — виводить дані у writer (за замовчуванням os.Stdout). Патерн Bridge: реалізатор.
+type ConsoleWriter struct {
+	writer io.Writer
+}
+
+// NewConsoleWriter — конструктор ConsoleWriter. Якщо w == nil, використовує os.Stdout.
+func NewConsoleWriter(w io.Writer) *ConsoleWriter {
+	if w == nil {
+		w = os.Stdout
+	}
+	return &ConsoleWriter{writer: w}
+}
+
+// Write — записує рядок у writer.
+func (c *ConsoleWriter) Write(data string) error {
+	_, err := fmt.Fprint(c.writer, data)
+	return err
+}
+
+// FileWriter — записує дані у writer (файл або буфер). Патерн Bridge: реалізатор.
+type FileWriter struct {
+	writer io.Writer
+}
+
+// NewFileWriter — конструктор FileWriter.
+func NewFileWriter(w io.Writer) *FileWriter {
+	return &FileWriter{writer: w}
+}
+
+// Write — записує рядок у writer.
+func (f *FileWriter) Write(data string) error {
+	_, err := fmt.Fprint(f.writer, data)
+	return err
+}
+
+// Formatter — базова абстракція у патерні Bridge. Містить посилання на реалізатор OutputWriter.
+// Конкретні форматери (TextFormatter, JSONFormatter) вбудовують цю структуру.
+type Formatter struct {
+	writer OutputWriter
+}
+
+// TextFormatter — форматує повідомлення як plain text ([LEVEL] message). Патерн Bridge: абстракція.
+type TextFormatter struct {
+	Formatter
+}
+
+// NewTextFormatter — конструктор TextFormatter.
+func NewTextFormatter(w OutputWriter) *TextFormatter {
+	return &TextFormatter{Formatter{writer: w}}
+}
+
+// Format — форматує повідомлення як [LEVEL] message та передає у writer.
+func (f *TextFormatter) Format(level, message string) error {
+	formatted := fmt.Sprintf("[%s] %s\n", level, message)
+	return f.writer.Write(formatted)
+}
+
+// JSONFormatter — форматує повідомлення як JSON. Патерн Bridge: абстракція.
+type JSONFormatter struct {
+	Formatter
+}
+
+// NewJSONFormatter — конструктор JSONFormatter.
+func NewJSONFormatter(w OutputWriter) *JSONFormatter {
+	return &JSONFormatter{Formatter{writer: w}}
+}
+
+// Format — форматує повідомлення як JSON та передає у writer.
+func (f *JSONFormatter) Format(level, message string) error {
+	formatted := fmt.Sprintf("{\"level\":%q,\"message\":%q}\n", level, message)
+	return f.writer.Write(formatted)
+}

--- a/internal/logging/bridge_test.go
+++ b/internal/logging/bridge_test.go
@@ -1,0 +1,124 @@
+// Package logging — тести для Bridge патерну (Formatter × OutputWriter).
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestBridge_AllCombinations — перевіряє всі 4 комбінації formatter + writer.
+func TestBridge_AllCombinations(t *testing.T) {
+	tests := []struct {
+		name       string
+		makeWriter func(buf *bytes.Buffer) OutputWriter
+		makeFormat func(w OutputWriter) interface {
+			Format(level, message string) error
+		}
+		wantContains string
+	}{
+		{
+			name: "TextFormatter + ConsoleWriter",
+			makeWriter: func(buf *bytes.Buffer) OutputWriter {
+				return NewConsoleWriter(buf)
+			},
+			makeFormat: func(w OutputWriter) interface {
+				Format(level, message string) error
+			} {
+				return NewTextFormatter(w)
+			},
+			wantContains: "[INFO] test message",
+		},
+		{
+			name: "TextFormatter + FileWriter",
+			makeWriter: func(buf *bytes.Buffer) OutputWriter {
+				return NewFileWriter(buf)
+			},
+			makeFormat: func(w OutputWriter) interface {
+				Format(level, message string) error
+			} {
+				return NewTextFormatter(w)
+			},
+			wantContains: "[INFO] test message",
+		},
+		{
+			name: "JSONFormatter + ConsoleWriter",
+			makeWriter: func(buf *bytes.Buffer) OutputWriter {
+				return NewConsoleWriter(buf)
+			},
+			makeFormat: func(w OutputWriter) interface {
+				Format(level, message string) error
+			} {
+				return NewJSONFormatter(w)
+			},
+			wantContains: `"level":"INFO"`,
+		},
+		{
+			name: "JSONFormatter + FileWriter",
+			makeWriter: func(buf *bytes.Buffer) OutputWriter {
+				return NewFileWriter(buf)
+			},
+			makeFormat: func(w OutputWriter) interface {
+				Format(level, message string) error
+			} {
+				return NewJSONFormatter(w)
+			},
+			wantContains: `"message":"test message"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			w := tc.makeWriter(&buf)
+			f := tc.makeFormat(w)
+
+			err := f.Format("INFO", "test message")
+			if err != nil {
+				t.Fatalf("Format returned error: %v", err)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, tc.wantContains) {
+				t.Errorf("expected output to contain %q, got: %q", tc.wantContains, output)
+			}
+		})
+	}
+}
+
+// TestBridge_JSONFormat — перевіряє що JSONFormatter виводить валідний JSON (є { та }).
+func TestBridge_JSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewConsoleWriter(&buf)
+	f := NewJSONFormatter(w)
+
+	err := f.Format("ERROR", "something failed")
+	if err != nil {
+		t.Fatalf("Format returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "{") || !strings.Contains(output, "}") {
+		t.Errorf("expected JSON format with braces, got: %q", output)
+	}
+}
+
+// TestBridge_TextFormat — перевіряє що TextFormatter виводить дужковий формат.
+func TestBridge_TextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewFileWriter(&buf)
+	f := NewTextFormatter(w)
+
+	err := f.Format("WARN", "something odd")
+	if err != nil {
+		t.Fatalf("Format returned error: %v", err)
+	}
+
+	output := buf.String()
+	if !strings.Contains(output, "[") || !strings.Contains(output, "]") {
+		t.Errorf("expected text format with brackets, got: %q", output)
+	}
+	if !strings.Contains(output, "something odd") {
+		t.Errorf("expected output to contain 'something odd', got: %q", output)
+	}
+}

--- a/internal/logging/proxy.go
+++ b/internal/logging/proxy.go
@@ -1,0 +1,114 @@
+// Package logging — Proxy та Bridge патерни для логування.
+// Proxy: LoggerProxy контролює доступ до FileLogger (лінива ініціалізація, підрахунок, фільтрація).
+// Bridge: Formatter абстракція × OutputWriter реалізація (bridge.go).
+package logging
+
+import (
+	"fmt"
+	"io"
+	"time"
+)
+
+// LogEntry — запис у журналі логування.
+type LogEntry struct {
+	Level     string `json:"level"`
+	Message   string `json:"message"`
+	Timestamp string `json:"timestamp"`
+}
+
+// Logger — інтерфейс логера. Proxy pattern: дозволяє підмінити реальний логер проксі.
+type Logger interface {
+	Log(level, message string)
+}
+
+// FileLogger — реальний логер, що записує у io.Writer. Патерн Proxy: реальний об'єкт.
+type FileLogger struct {
+	writer io.Writer
+}
+
+// NewFileLogger — конструктор FileLogger.
+func NewFileLogger(w io.Writer) *FileLogger {
+	return &FileLogger{writer: w}
+}
+
+// Log — записує рядок у форматі [LEVEL] message у writer.
+func (l *FileLogger) Log(level, message string) {
+	fmt.Fprintf(l.writer, "[%s] %s\n", level, message)
+}
+
+// levelValue — допоміжна функція для порівняння рівнів логування.
+// info=0, warn=1, error=2. Невідомий рівень повертає -1.
+func levelValue(level string) int {
+	switch level {
+	case "info":
+		return 0
+	case "warn":
+		return 1
+	case "error":
+		return 2
+	default:
+		return -1
+	}
+}
+
+// LoggerProxy — проксі для Logger. Патерн Proxy: додає лінню ініціалізацію, підрахунок викликів та фільтрацію за рівнем.
+type LoggerProxy struct {
+	realLogger Logger
+	writer     io.Writer
+	minLevel   string
+	entries    []LogEntry
+	logCount   int
+}
+
+// NewLoggerProxy — конструктор LoggerProxy. realLogger залишається nil до першого виклику Log.
+func NewLoggerProxy(w io.Writer, minLevel string) *LoggerProxy {
+	return &LoggerProxy{
+		writer:   w,
+		minLevel: minLevel,
+		entries:  []LogEntry{},
+	}
+}
+
+// Log — делегує запис реальному логеру (lazy init), рахує записи та фільтрує за рівнем.
+func (p *LoggerProxy) Log(level, message string) {
+	// Фільтрація за мінімальним рівнем
+	if levelValue(level) < levelValue(p.minLevel) {
+		return
+	}
+
+	// Лінна ініціалізація реального логера
+	if p.realLogger == nil {
+		p.realLogger = NewFileLogger(p.writer)
+	}
+
+	// Делегування реальному логеру
+	p.realLogger.Log(level, message)
+
+	// Збереження запису в пам'яті
+	p.entries = append(p.entries, LogEntry{
+		Level:     level,
+		Message:   message,
+		Timestamp: time.Now().Format(time.RFC3339),
+	})
+	p.logCount++
+}
+
+// GetLogCount — повертає кількість записів у лозі.
+func (p *LoggerProxy) GetLogCount() int {
+	return p.logCount
+}
+
+// GetEntries — повертає записи з логу. Якщо level порожній — всі записи, інакше — тільки з вказаним рівнем.
+func (p *LoggerProxy) GetEntries(level string) []LogEntry {
+	if level == "" {
+		return p.entries
+	}
+
+	filtered := []LogEntry{}
+	for _, e := range p.entries {
+		if e.Level == level {
+			filtered = append(filtered, e)
+		}
+	}
+	return filtered
+}

--- a/internal/logging/proxy_test.go
+++ b/internal/logging/proxy_test.go
@@ -1,0 +1,110 @@
+// Package logging — Proxy та Bridge патерни для логування.
+package logging
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// TestLoggerProxy_LazyInit — перевіряє ліниву ініціалізацію реального логера.
+func TestLoggerProxy_LazyInit(t *testing.T) {
+	var buf bytes.Buffer
+	proxy := NewLoggerProxy(&buf, "info")
+
+	// До першого виклику Log — logCount має бути 0
+	if proxy.GetLogCount() != 0 {
+		t.Errorf("expected logCount 0 before any Log call, got %d", proxy.GetLogCount())
+	}
+
+	// realLogger має бути nil до першого виклику
+	if proxy.realLogger != nil {
+		t.Error("expected realLogger to be nil before first Log call")
+	}
+
+	proxy.Log("info", "test")
+
+	// Після першого виклику — logCount має бути 1
+	if proxy.GetLogCount() != 1 {
+		t.Errorf("expected logCount 1 after one Log call, got %d", proxy.GetLogCount())
+	}
+
+	// realLogger має бути ініціалізований
+	if proxy.realLogger == nil {
+		t.Error("expected realLogger to be initialized after first Log call")
+	}
+}
+
+// TestLoggerProxy_CountsLogs — перевіряє підрахунок записів у логі.
+func TestLoggerProxy_CountsLogs(t *testing.T) {
+	var buf bytes.Buffer
+	proxy := NewLoggerProxy(&buf, "info")
+
+	proxy.Log("info", "msg1")
+	proxy.Log("warn", "msg2")
+	proxy.Log("error", "msg3")
+
+	if proxy.GetLogCount() != 3 {
+		t.Errorf("expected logCount 3, got %d", proxy.GetLogCount())
+	}
+}
+
+// TestLoggerProxy_LevelFiltering — перевіряє фільтрацію записів за рівнем.
+func TestLoggerProxy_LevelFiltering(t *testing.T) {
+	var buf bytes.Buffer
+	proxy := NewLoggerProxy(&buf, "warn")
+
+	proxy.Log("info", "this should be skipped")
+	proxy.Log("warn", "this should pass")
+	proxy.Log("error", "this should also pass")
+
+	if proxy.GetLogCount() != 2 {
+		t.Errorf("expected logCount 2 (info skipped), got %d", proxy.GetLogCount())
+	}
+
+	if strings.Contains(buf.String(), "this should be skipped") {
+		t.Error("expected info message to be filtered out, but it was written to buffer")
+	}
+}
+
+// TestLoggerProxy_GetEntries — перевіряє отримання записів за рівнем.
+func TestLoggerProxy_GetEntries(t *testing.T) {
+	var buf bytes.Buffer
+	proxy := NewLoggerProxy(&buf, "info")
+
+	proxy.Log("info", "info message")
+	proxy.Log("warn", "warn message")
+	proxy.Log("error", "error message 1")
+	proxy.Log("error", "error message 2")
+
+	// Отримати тільки error записи
+	errorEntries := proxy.GetEntries("error")
+	if len(errorEntries) != 2 {
+		t.Errorf("expected 2 error entries, got %d", len(errorEntries))
+	}
+
+	for _, e := range errorEntries {
+		if e.Level != "error" {
+			t.Errorf("expected all entries to have level 'error', got '%s'", e.Level)
+		}
+	}
+
+	// Отримати всі записи
+	allEntries := proxy.GetEntries("")
+	if len(allEntries) != 4 {
+		t.Errorf("expected 4 total entries, got %d", len(allEntries))
+	}
+}
+
+// TestLoggerProxy_WritesToRealLogger — перевіряє що запис делегується реальному логеру.
+func TestLoggerProxy_WritesToRealLogger(t *testing.T) {
+	var buf bytes.Buffer
+	proxy := NewLoggerProxy(&buf, "info")
+
+	proxy.Log("info", "hello world")
+
+	output := buf.String()
+	if !strings.Contains(output, "hello world") {
+		t.Errorf("expected buffer to contain 'hello world', got: %q", output)
+	}
+}

--- a/internal/notify/facade.go
+++ b/internal/notify/facade.go
@@ -1,0 +1,78 @@
+// Package notify реалізує патерн Facade для відправки нотифікацій через кілька каналів.
+package notify
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+)
+
+// Notifier — інтерфейс підсистеми нотифікацій.
+type Notifier interface {
+	Notify(userID, message string) error
+}
+
+// ConsoleNotifier — підсистема: виводить нотифікацію в консоль.
+type ConsoleNotifier struct {
+	writer io.Writer
+}
+
+// NewConsoleNotifier — конструктор ConsoleNotifier з виводом у os.Stdout за замовчуванням.
+func NewConsoleNotifier() *ConsoleNotifier {
+	return &ConsoleNotifier{writer: os.Stdout}
+}
+
+// Notify записує повідомлення у вигляді [CONSOLE] User userID: message.
+func (n *ConsoleNotifier) Notify(userID, message string) error {
+	_, err := fmt.Fprintf(n.writer, "[CONSOLE] User %s: %s\n", userID, message)
+	return err
+}
+
+// FileNotifier — підсистема: записує нотифікацію у writer (у production — файл).
+type FileNotifier struct {
+	writer io.Writer
+}
+
+// NewFileNotifier — конструктор FileNotifier з переданим io.Writer.
+func NewFileNotifier(w io.Writer) *FileNotifier {
+	return &FileNotifier{writer: w}
+}
+
+// Notify записує повідомлення у вигляді [FILE] User userID: message.
+func (n *FileNotifier) Notify(userID, message string) error {
+	_, err := fmt.Fprintf(n.writer, "[FILE] User %s: %s\n", userID, message)
+	return err
+}
+
+// NotificationFacade — фасад, який приховує складність роботи з кількома каналами нотифікацій.
+type NotificationFacade struct {
+	notifiers []Notifier
+}
+
+// NewNotificationFacade — конструктор NotificationFacade з ConsoleNotifier та FileNotifier.
+func NewNotificationFacade(console io.Writer, file io.Writer) *NotificationFacade {
+	return &NotificationFacade{
+		notifiers: []Notifier{
+			&ConsoleNotifier{writer: console},
+			&FileNotifier{writer: file},
+		},
+	}
+}
+
+// NotifyUser відправляє повідомлення через усі канали нотифікацій, агрегуючи помилки.
+func (f *NotificationFacade) NotifyUser(userID, message string) error {
+	var errs []error
+	for _, n := range f.notifiers {
+		if err := n.Notify(userID, message); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// NotifyOrderStatusChanged форматує повідомлення про зміну статусу замовлення і надсилає через всі канали.
+func (f *NotificationFacade) NotifyOrderStatusChanged(orderID, status string) error {
+	message := fmt.Sprintf("Order %s status changed to %s", orderID, status)
+	return f.NotifyUser("system", message)
+}

--- a/internal/notify/facade_test.go
+++ b/internal/notify/facade_test.go
@@ -1,0 +1,83 @@
+package notify
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// failingWriter — io.Writer що завжди повертає помилку (для тестування error propagation).
+type failingWriter struct{}
+
+func (fw *failingWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
+// TestNotifyUser_SendsToBothChannels перевіряє що NotifyUser пише в обидва канали.
+func TestNotifyUser_SendsToBothChannels(t *testing.T) {
+	var consoleBuf, fileBuf bytes.Buffer
+	facade := NewNotificationFacade(&consoleBuf, &fileBuf)
+
+	err := facade.NotifyUser("user1", "test message")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	consoleOut := consoleBuf.String()
+	fileOut := fileBuf.String()
+
+	if !strings.Contains(consoleOut, "[CONSOLE]") {
+		t.Errorf("console output missing [CONSOLE] prefix, got: %q", consoleOut)
+	}
+	if !strings.Contains(consoleOut, "user1") {
+		t.Errorf("console output missing userID, got: %q", consoleOut)
+	}
+	if !strings.Contains(consoleOut, "test message") {
+		t.Errorf("console output missing message, got: %q", consoleOut)
+	}
+
+	if !strings.Contains(fileOut, "[FILE]") {
+		t.Errorf("file output missing [FILE] prefix, got: %q", fileOut)
+	}
+	if !strings.Contains(fileOut, "user1") {
+		t.Errorf("file output missing userID, got: %q", fileOut)
+	}
+	if !strings.Contains(fileOut, "test message") {
+		t.Errorf("file output missing message, got: %q", fileOut)
+	}
+}
+
+// TestNotifyOrderStatusChanged_FormatsMessage перевіряє форматування повідомлення.
+func TestNotifyOrderStatusChanged_FormatsMessage(t *testing.T) {
+	var consoleBuf, fileBuf bytes.Buffer
+	facade := NewNotificationFacade(&consoleBuf, &fileBuf)
+
+	err := facade.NotifyOrderStatusChanged("order-1", "shipped")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	consoleOut := consoleBuf.String()
+
+	if !strings.Contains(consoleOut, "order-1") {
+		t.Errorf("output missing orderID, got: %q", consoleOut)
+	}
+	if !strings.Contains(consoleOut, "shipped") {
+		t.Errorf("output missing status, got: %q", consoleOut)
+	}
+}
+
+// TestFacade_ErrorPropagation перевіряє що facade повертає помилку якщо notifier завершується з помилкою.
+func TestFacade_ErrorPropagation(t *testing.T) {
+	fw := &failingWriter{}
+	var goodBuf bytes.Buffer
+
+	// ConsoleNotifier буде failing, FileNotifier — good
+	facade := NewNotificationFacade(fw, &goodBuf)
+
+	err := facade.NotifyUser("user1", "hello")
+	if err == nil {
+		t.Error("expected non-nil error when a notifier fails, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #8

Реалізовано модуль оповіщень через патерн Facade, логування з lazy initialization через Proxy, та гнучкий вивід через Bridge. Створено два нові пакети: `internal/notify` для уніфікованої відправки нотифікацій та `internal/logging` для проксі-логера та форматування виводу.

## Використані патерни

### Facade

**Файл:** `internal/notify/facade.go`

**Проблема:** Для відправки нотифікацій потрібно координувати кілька каналів (консоль, файл). Кожен виклик вимагає знання про всі підсистеми та правильну послідовність дій — це ускладнює клієнтський код.

**Рішення:** `NotificationFacade` інкапсулює масив `Notifier` (інтерфейс з методом `Notify(userID, message) error`). Дві підсистеми: `ConsoleNotifier` (пише в stdout з префіксом `[CONSOLE]`) та `FileNotifier` (пише в файл/writer з префіксом `[FILE]`). Метод `NotifyUser(userID, message)` ітерує всі нотифікатори та агрегує помилки через `errors.Join`. `NotifyOrderStatusChanged(orderID, status)` форматує повідомлення та делегує `NotifyUser`.

**Чому саме тут:** Facade приховує складність взаємодії з кількома каналами за одним методом. Handler викликає лише `facade.NotifyUser(...)` — деталі маршрутизації по каналах приховані. Додавання нового каналу (email, Slack) = додавання нового Notifier без зміни API.

### Proxy

**Файл:** `internal/logging/proxy.go`

**Проблема:** FileLogger потребує ініціалізації файлу, що дорого робити при старті, якщо логування може не використовуватись. Також потрібно рахувати кількість логів та фільтрувати за рівнем (info/warn/error) без зміни реального логера.

**Рішення:** `Logger` інтерфейс з методом `Log(level, message)`. `FileLogger` — реальний логер, що пише у writer. `LoggerProxy` — проксі з трьома додатковими поведінками: (1) lazy init — `FileLogger` створюється тільки при першому виклику `Log()`, (2) лічильник `GetLogCount() int`, (3) фільтрація за мінімальним рівнем через `levelValue()` (info=0, warn=1, error=2). Також зберігає `LogEntry` записи in-memory з можливістю фільтрації через `GetEntries(level)`.

**Чому саме тут:** Proxy додає функціональність (counting, filtering, lazy init) без зміни інтерфейсу Logger. Клієнтський код працює з `Logger` і не знає, чи це реальний логер чи проксі. Lazy init особливо корисний — файл створюється тільки коли дійсно потрібно логувати.

### Bridge

**Файл:** `internal/logging/bridge.go`

**Проблема:** Потрібно комбінувати різні формати виводу (text, JSON) з різними місцями призначення (консоль, файл). Без Bridge кожна комбінація вимагає окремого класу (TextConsole, TextFile, JSONConsole, JSONFile = 4 класи), і додавання нового формату або writer подвоює кількість класів.

**Рішення:** Дві незалежні ієрархії: `OutputWriter` інтерфейс (implementor) з `ConsoleWriter` та `FileWriter`; `Formatter` базова структура з полем `writer OutputWriter` (abstraction). `TextFormatter` форматує як plain text (`[LEVEL] message`), `JSONFormatter` як JSON. Будь-який Formatter працює з будь-яким Writer — 2×2=4 комбінації з 4 типів замість 4 окремих класів.

**Чому саме тут:** Bridge розділяє "як форматувати" від "куди писати". Додавання XMLFormatter = 1 новий тип (не 2). Додавання NetworkWriter = 1 новий тип (не 3). Це демонструє ключову перевагу Bridge — лінійне зростання замість мультиплікативного.

## Тести

- `internal/notify/facade_test.go` — тести Facade: NotifyUser відправляє в обидва канали, NotifyOrderStatusChanged форматує повідомлення, propagation помилок через errors.Join
- `internal/logging/proxy_test.go` — тести Proxy: lazy init (FileLogger не створюється до першого Log), лічильник логів, фільтрація за рівнем (info/warn/error), GetEntries з фільтрацією
- `internal/logging/bridge_test.go` — тести Bridge: всі 4 комбінації formatter×writer (TextFormatter+ConsoleWriter, TextFormatter+FileWriter, JSONFormatter+ConsoleWriter, JSONFormatter+FileWriter)
- `internal/handler/notifications_test.go` — тести HTTP handlers: POST /api/notifications/send (успіх, невалідний JSON), GET /api/logs (всі, з фільтром по рівню), GET /api/logs/stats